### PR TITLE
feat(RELEASE): allow overriding build.sh 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN  apk update \
     && update-ca-certificates    
 
 # Download TileBoard
-RUN wget -q -O release.zip "%RELEASE_URL%" \
+ARG RELEASE_URL
+RUN wget -q -O release.zip "${RELEASE_URL:-%RELEASE_URL%}" \
     && unzip release.zip -d /tileboard/ \
     && rm release.zip
 

--- a/build.sh
+++ b/build.sh
@@ -32,18 +32,13 @@ echo "Docker repository: $docker_repo."
 
 LATEST_RELEASE=`getVersionFromLatestRelease $source_repo`
 echo "Latest release is: $LATEST_RELEASE."
-echo "::set-output name=latest_release::$LATEST_RELEASE"
 
 SEMVER=( ${LATEST_RELEASE//./ } )
 MAJOR=${SEMVER[0]}
 MINOR=${SEMVER[0]}.${SEMVER[1]}
 PATCH=$LATEST_RELEASE
-echo "::set-output name=major::$MAJOR"
-echo "::set-output name=minor::$MINOR"
-echo "::set-output name=patch::$PATCH"
 
 echo "latest,$MAJOR,$MINOR,$PATCH" > .tags
-echo "::set-output name=tags::$(cat .tags)"
 
 RELEASE_URL=`getDownloadUrl`
 echo "URL of release is: $RELEASE_URL."

--- a/build.sh
+++ b/build.sh
@@ -32,21 +32,27 @@ echo "Docker repository: $docker_repo."
 
 LATEST_RELEASE=`getVersionFromLatestRelease $source_repo`
 echo "Latest release is: $LATEST_RELEASE."
-
-if docker_tag_exists $docker_repo $LATEST_RELEASE; then
-    echo "Nothing to do. Latest release tag already exists."
-    exit 78 # drone.io exit code to stop but success the pipeline
-fi
+echo "::set-output name=latest_release::$LATEST_RELEASE"
 
 SEMVER=( ${LATEST_RELEASE//./ } )
 MAJOR=${SEMVER[0]}
 MINOR=${SEMVER[0]}.${SEMVER[1]}
 PATCH=$LATEST_RELEASE
+echo "::set-output name=major::$MAJOR"
+echo "::set-output name=minor::$MINOR"
+echo "::set-output name=patch::$PATCH"
 
 echo "latest,$MAJOR,$MINOR,$PATCH" > .tags
+echo "::set-output name=tags::$(cat .tags)"
 
 RELEASE_URL=`getDownloadUrl`
 echo "URL of release is: $RELEASE_URL."
+echo "::set-output name=release_url::$RELEASE_URL"
+
+if docker_tag_exists $docker_repo $LATEST_RELEASE; then
+    echo "Nothing to do. Latest release tag already exists."
+    exit 78 # drone.io exit code to stop but success the pipeline
+fi
 
 echo "Writing release URL into Dockerfile..."
 sed -i "s|%RELEASE_URL%|$RELEASE_URL|g" ./Dockerfile


### PR DESCRIPTION
I'm experimenting with GitHub workflows and found the current setup has some minor flaws that prevent building the images, if the current release is already compiled and available on Docker hub. This is necessary, e.g., when requesting a build manually, or if only the `Dockerfile`has changed. This PR fixes those issues in the following way:
* add `ARG` for `RELEASE_URL`
* make `build.sh` prepare `.tags` even if tag exists
* add output `release_url` to be used by github workflows

`build.sh` is still aborted before changing `Dockerfile`, so people can run it locally without modify the git repo. `.arg` may be changed, because it is `.gitignore`d.

Here's an example of how to use the changed script in a GitHub workflow: 
https://github.com/akloeckner/TileBoard-docker/blob/26e167b4d57bbca1913f75e3f100aa22babf3973/.github/workflows/release.yml#L32

There should be no impact on current build setups. (Other than a somewhat cryptic `echo` of the release URL.)