### PR TITLE
feat(NIGHTLY): efficient multi-platform images

### DIFF
--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -3,7 +3,8 @@ ARG DEVPLATFORM=${TARGETPLATFORM:-linux/amd64}
 FROM --platform=$DEVPLATFORM node:15-alpine AS dev
 
 # Install pre-requisites
-RUN case $DEVPLATFORM in \
+RUN echo DEVPLATFORM: $DEVPLATFORM \
+ && case $DEVPLATFORM in \
     *arm*) apk add --no-cache git python3 build-base ;; \
     *)     apk add --no-cache git python3 ;; \
     esac

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,14 +1,10 @@
 ## DEVELOPMENT IMAGE
-ARG DEVPLATFORM=${TARGETPLATFORM:-linux/amd64}
-FROM --platform=$DEVPLATFORM node:15-alpine AS dev
+# Note: When building cross-platform nightly images, use --platform=<native-arch> to increase efficiency.
+FROM node:15-alpine AS dev
 
 # Install pre-requisites
-ARG DEVPLATFORM
-RUN echo DEVPLATFORM: $DEVPLATFORM \
- && case $DEVPLATFORM in \
-    *arm*) apk add --no-cache git python3 build-base ;; \
-    *)     apk add --no-cache git python3 ;; \
-    esac
+# Note: On ARM, also install build-base for compiling the node-sass dependency.
+RUN apk add --no-cache git python3
 
 # Fetch and build tileboard master branch
 RUN mkdir /tileboard-source \

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -2,7 +2,7 @@
 FROM node:15-alpine AS dev
 
 # Install pre-requisites
-RUN apk add --no-cache git python3
+RUN apk add --no-cache git python3 build-base
 
 # Fetch and build tileboard master branch
 RUN mkdir /tileboard-source \

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,8 +1,12 @@
 ## DEVELOPMENT IMAGE
-FROM node:15-alpine AS dev
+ARG DEVPLATFORM=${TARGETPLATFORM:-linux/amd64}
+FROM --platform=$DEVPLATFORM node:15-alpine AS dev
 
 # Install pre-requisites
-RUN apk add --no-cache git python3 build-base
+RUN case $DEVPLATFORM in \
+    *arm*) apk add --no-cache git python3 build-base ;; \
+    *)     apk add --no-cache git python3 ;; \
+    esac
 
 # Fetch and build tileboard master branch
 RUN mkdir /tileboard-source \

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -3,6 +3,7 @@ ARG DEVPLATFORM=${TARGETPLATFORM:-linux/amd64}
 FROM --platform=$DEVPLATFORM node:15-alpine AS dev
 
 # Install pre-requisites
+ARG DEVPLATFORM
 RUN echo DEVPLATFORM: $DEVPLATFORM \
  && case $DEVPLATFORM in \
     *arm*) apk add --no-cache git python3 build-base ;; \


### PR DESCRIPTION
When cross-building on emulated patforms, the compilation of things such as `node-sass` or the likes is creepingly slow, because required `Node.JS` packages are not available pre-compiled'ly. Since the `nightly` image actually only requires the final JavaScript output, the compilation of the `rollup.js` dependencies can be done on an arbitrary platform, e.g. the native platform of the builder, i.e. `amd64` most likely.

So, this PR introduces a new build argument `DEVPLATFORM` to `Dockerfile.nightly`. It is used to select the `dev` platform. The argument is similar to the default `BUILDPLATFORM` and `TARGETPLATFORM` arguments in `buildx`. In order for multi-platform `dev` image to run without configuration, `DEVPLATFORM` defaults to `TARGETPLATFORM`, with a fallback to `linux/amd64` if built without `buildx`. The `DEVPLATFORM` can be overwritten to efficiently build the nightly image. See example here:
https://github.com/akloeckner/TileBoard-docker/blob/26e167b4d57bbca1913f75e3f100aa22babf3973/.github/workflows/nightly.yml#L57

Also, it turns out that some build dependencies are not included in the `arm` platforms. This is why, for those platforms, we need to install them.

Be aware: While building multi-platform `nightly` images is as performant as building for `amd64` only, the `dev` images take almost two hours to complete on GitHub due to compiling the dependencies. See here: https://github.com/akloeckner/TileBoard-docker/actions/runs/860754588

Expected impact on currenty build setups: If you are not using `buildx` and a build platform other than `amd64`, building the images will probably fail, because of the bad default argument to `DEVPLATFORM`. We can change the default argument to something more suitable for you then.